### PR TITLE
Fix executive actions not triggering sometimes

### DIFF
--- a/secret_hitler/app.py
+++ b/secret_hitler/app.py
@@ -364,7 +364,7 @@ async def nominate(ctx, player : commands.MemberConverter):
         return
 
     if not game.nominate(player.id):
-        await ctx.send("This player could not be nominated. He was chancellor or president in the last round")
+        await ctx.send("This player could not be nominated. They were chancellor or president in the last round")
         return
 
     await ctx.message.delete()

--- a/secret_hitler/game.py
+++ b/secret_hitler/game.py
@@ -348,17 +348,17 @@ class Game:
 
         img_new.save("secret_hitler/img/chancellor_"+str(self.game_id)+".png")
 
-    def discard_policy(self, player_id, policy):
-        policy = policy.upper()
+    def discard_policy(self, player_id, card):
+        card = card.upper()
         if (self.state is GameStates.LEGISLATIVE_PRESIDENT and self.president.player_id is player_id) or (self.state is GameStates.LEGISLATIVE_CHANCELLOR and self.chancellor.player_id is player_id):
-            if policy == 'F' or policy == 'L':
+            if card == 'F' or card == 'L':
                 for i in range(len(self.policies)):
-                    print(i)
-                    if self.policies[i] == policy:
+                    if self.policies[i] == card:
                         popped =  self.policies[i]
                         self.policies.pop(i)
                         self.discard.append(popped)
                         if len(self.policies) == 1:
+                            policy = self.policies[0]
                             self.place_policy(self.policies[0])
                             if self.state == GameStates.GAME_OVER:
                                 return True


### PR DESCRIPTION
It was looking at the discarded policy to determine if fascist policies should be enacted, instead of the actually enacted policy. This causes executive actions to be skipped when, for example, a fascist discards an L to enact fascism.

Unrelated, I also made an error message gender neutral (more than half the people I played with are female, so the old error didn't make any sense)